### PR TITLE
Streaming api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 example/main
 example/large/large
+example/example1/example1
 
 # Test workbooks
 *.xlsx

--- a/example/example1/main.go
+++ b/example/example1/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
-	"github.com/sean-duffy/xlsx"
+	"time"
+
+	"github.com/psmithuk/xlsx"
 )
 
 func main() {
@@ -49,6 +51,6 @@ func main() {
 
 	err := sh.SaveToFile("test.xlsx")
 	if err != nil {
-		log.Print(err)
+		println(err)
 	}
 }

--- a/example/example1/main.go
+++ b/example/example1/main.go
@@ -27,7 +27,7 @@ func main() {
 	}
 	r.Cells[2] = xlsx.Cell{
 		Type:  xlsx.CellTypeDatetime,
-		Value: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		Value: time.Date(1980, 4, 24, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
 	}
 
 	sh.AppendRow(r)
@@ -44,7 +44,7 @@ func main() {
 	}
 	r2.Cells[2] = xlsx.Cell{
 		Type:  xlsx.CellTypeDatetime,
-		Value: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		Value: time.Date(2008, 1, 9, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
 	}
 
 	sh.AppendRow(r2)

--- a/example/example1/main.go
+++ b/example/example1/main.go
@@ -1,12 +1,7 @@
 package main
 
 import (
-	"fmt"
-	"log"
-	"strconv"
-	"time"
-
-	"github.com/psmithuk/xlsx"
+	"github.com/sean-duffy/xlsx"
 )
 
 func main() {
@@ -52,7 +47,7 @@ func main() {
 
 	sh.AppendRow(r2)
 
-	err := sh.SaveToFile("/tmp/test.xlsx")
+	err := sh.SaveToFile("test.xlsx")
 	if err != nil {
 		log.Print(err)
 	}

--- a/example/large/main.go
+++ b/example/large/main.go
@@ -1,11 +1,18 @@
 package main
 
 import (
+	"bufio"
 	"github.com/sean-duffy/xlsx"
+	"os"
 	"strconv"
 )
 
 func main() {
+
+	outputfile, err := os.Create("test.xlsx")
+
+	w := bufio.NewWriter(outputfile)
+	ww := xlsx.NewWorkbookWriter(w)
 
 	c := []xlsx.Column{
 		xlsx.Column{Name: "Col1", Width: 10},
@@ -15,7 +22,9 @@ func main() {
 	sh := xlsx.NewSheetWithColumns(c)
 	sh.Title = "MySheet"
 
-	for i := 0; i < 10; i++ {
+	sw, err := ww.NewSheetWriter(&sh)
+
+	for i := 0; i < 1000000; i++ {
 
 		r := sh.NewRow()
 
@@ -28,9 +37,13 @@ func main() {
 			Value: "1",
 		}
 
-		sh.AppendRow(r)
+		err = sw.WriteRows([]xlsx.Row{r})
 	}
 
-	err := sh.SaveToFile("test.xlsx")
-	_ = err
+	err = ww.Close()
+	defer w.Flush()
+
+	if err != nil {
+		panic(err)
+	}
 }

--- a/example/large/main.go
+++ b/example/large/main.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"bufio"
-	"github.com/sean-duffy/xlsx"
 	"os"
 	"strconv"
+
+	"github.com/sean-duffy/xlsx"
 )
 
 func main() {
@@ -24,7 +25,7 @@ func main() {
 
 	sw, err := ww.NewSheetWriter(&sh)
 
-	for i := 0; i < 1000000; i++ {
+	for i := 0; i < 100000; i++ {
 
 		r := sh.NewRow()
 

--- a/example/large/main.go
+++ b/example/large/main.go
@@ -44,8 +44,8 @@ func WriteStreaming() error {
 			Value: strconv.Itoa(i + 1),
 		}
 		r.Cells[1] = xlsx.Cell{
-			Type:  xlsx.CellTypeNumber,
-			Value: "1",
+			Type:  xlsx.CellTypeInlineString,
+			Value: "Test",
 		}
 
 		err = sw.WriteRows([]xlsx.Row{r})

--- a/example/large/main.go
+++ b/example/large/main.go
@@ -9,7 +9,17 @@ import (
 )
 
 func main() {
+	err := WriteStreaming()
+	//err := WriteNoStreaming()
 
+	if err != nil {
+		panic(err)
+	}
+}
+
+// Write a simple 1,000,000 row spreadsheet using streaming
+// This has a maximum resident set of ~6.6MB
+func WriteStreaming() error {
 	outputfile, err := os.Create("test.xlsx")
 
 	w := bufio.NewWriter(outputfile)
@@ -25,7 +35,7 @@ func main() {
 
 	sw, err := ww.NewSheetWriter(&sh)
 
-	for i := 0; i < 100000; i++ {
+	for i := 0; i < 1000000; i++ {
 
 		r := sh.NewRow()
 
@@ -44,7 +54,37 @@ func main() {
 	err = ww.Close()
 	defer w.Flush()
 
-	if err != nil {
-		panic(err)
+	return err
+}
+
+// Write a simple 1,000,000 row spreadsheet without using streaming
+// This has a maximum resident set of ~240MB
+func WriteNoStreaming() error {
+	c := []xlsx.Column{
+		xlsx.Column{Name: "Col1", Width: 10},
+		xlsx.Column{Name: "Col2", Width: 10},
 	}
+
+	sh := xlsx.NewSheetWithColumns(c)
+	sh.Title = "MySheet"
+
+	for i := 0; i < 1000000; i++ {
+
+		r := sh.NewRow()
+
+		r.Cells[0] = xlsx.Cell{
+			Type:  xlsx.CellTypeNumber,
+			Value: strconv.Itoa(i + 1),
+		}
+		r.Cells[1] = xlsx.Cell{
+			Type:  xlsx.CellTypeNumber,
+			Value: "1",
+		}
+
+		sh.AppendRow(r)
+	}
+
+	err := sh.SaveToFile("test.xlsx")
+
+	return err
 }

--- a/example/large/main.go
+++ b/example/large/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/sean-duffy/xlsx"
+	"github.com/psmithuk/xlsx"
 )
 
 func main() {

--- a/templates.go
+++ b/templates.go
@@ -61,7 +61,6 @@ const templateContentTypes = `<?xml version="1.0" encoding="UTF-8" standalone="y
       <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
       <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
       <Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>
-      <Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>
       <Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>
       <Override PartName="/docProps/app.xml" ContentType="application/vnd.openxmlformats-officedocument.extended-properties+xml"/>
   </Types>`
@@ -89,7 +88,6 @@ const templateWorkbook = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?
 const templateWorkbookRelationships = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
   <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
       <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
-      <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="sharedStrings.xml"/>
       <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
   </Relationships>`
 

--- a/templates.go
+++ b/templates.go
@@ -61,6 +61,7 @@ const templateContentTypes = `<?xml version="1.0" encoding="UTF-8" standalone="y
       <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
       <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
       <Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>
+      <Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>
       <Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>
       <Override PartName="/docProps/app.xml" ContentType="application/vnd.openxmlformats-officedocument.extended-properties+xml"/>
   </Types>`
@@ -88,6 +89,7 @@ const templateWorkbook = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?
 const templateWorkbookRelationships = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
   <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
       <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+      <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="sharedStrings.xml"/>
       <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
   </Relationships>`
 

--- a/templates.go
+++ b/templates.go
@@ -20,6 +20,7 @@ var (
 	TemplateCellNumber            *template.Template
 	TemplateCellString            *template.Template
 	TemplateCellDateTime          *template.Template
+	TemplateCellInlineString      *template.Template
 	TemplateApp                   *template.Template
 	TemplateCore                  *template.Template
 )
@@ -50,6 +51,7 @@ func init() {
 	TemplateCellNumber = template.Must(template.New("templateCellNumber").Funcs(funcMap).Parse(re.ReplaceAllLiteralString(templateCellNumber, "")))
 	TemplateCellString = template.Must(template.New("templateCellString").Funcs(funcMap).Parse(re.ReplaceAllLiteralString(templateCellString, "")))
 	TemplateCellDateTime = template.Must(template.New("templateCellDateTime").Funcs(funcMap).Parse(re.ReplaceAllLiteralString(templateCellDateTime, "")))
+	TemplateCellInlineString = template.Must(template.New("templateCellInlineString").Funcs(funcMap).Parse(re.ReplaceAllLiteralString(templateCellInlineString, "")))
 	TemplateApp = template.Must(template.New("templateApp").Funcs(funcMap).Parse(re.ReplaceAllLiteralString(templateApp, "")))
 	TemplateCore = template.Must(template.New("templateCore").Funcs(funcMap).Parse(re.ReplaceAllLiteralString(templateCore, "")))
 }
@@ -167,6 +169,7 @@ const templateSheetEnd = `
 const templateCellNumber = `<c r="{{.CellIndex}}" t="n" s="1"><v>{{.Value}}</v></c>`
 const templateCellString = `<c r="{{.CellIndex}}" t="s" s="1"><v>{{.Value}}</v></c>`
 const templateCellDateTime = `<c r="{{.CellIndex}}" s="2"><v>{{.Value}}</v></c>`
+const templateCellInlineString = `<c r="{{.CellIndex}}" t="inlineStr"><is><t>{{.Value}}</t></is></c>`
 
 const templateApp = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
   <Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties" xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">

--- a/xlsx.go
+++ b/xlsx.go
@@ -232,7 +232,7 @@ type WorkbookWriter struct {
 // NewWorkbookWriter creates a new WorkbookWriter, which SheetWriters will
 // operate on. It must be closed when all Sheets have been written.
 func NewWorkbookWriter(w io.Writer) *WorkbookWriter {
-	return &WorkbookWriter{zip.NewWriter(w), nil, false}
+	return &WorkbookWriter{zip.NewWriter(w), nil, false, false}
 }
 
 // Write the header files of the workbook

--- a/xlsx.go
+++ b/xlsx.go
@@ -7,10 +7,10 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"html"
+	//"html"
 	"io"
 	"os"
-	"strconv"
+	//"strconv"
 	"time"
 )
 
@@ -116,27 +116,27 @@ func (s *Sheet) AppendRow(r Row) error {
 
 	cells := make([]Cell, len(s.columns))
 
-	for n, c := range r.Cells {
-		cells[n].Type = c.Type
-		cells[n].Value = c.Value
+	//for n, c := range r.Cells {
+	//	cells[n].Type = c.Type
+	//	cells[n].Value = c.Value
 
-		if cells[n].Type == CellTypeString {
-			// calculate string reference
-			cells[n].Value = html.EscapeString(cells[n].Value)
-			i, exists := s.sharedStringMap[cells[n].Value]
-			if !exists {
-				i = len(s.sharedStrings)
-				s.sharedStringMap[cells[n].Value] = i
-				s.sharedStrings = append(s.sharedStrings, cells[n].Value)
-			}
-			cells[n].Value = strconv.Itoa(i)
-		} else if cells[n].Type == CellTypeDatetime {
-			d, err := time.Parse(time.RFC3339, cells[n].Value)
-			if err == nil {
-				cells[n].Value = OADate(d)
-			}
-		}
-	}
+	//	if cells[n].Type == CellTypeString {
+	//		// calculate string reference
+	//		cells[n].Value = html.EscapeString(cells[n].Value)
+	//		i, exists := s.sharedStringMap[cells[n].Value]
+	//		if !exists {
+	//			i = len(s.sharedStrings)
+	//			s.sharedStringMap[cells[n].Value] = i
+	//			s.sharedStrings = append(s.sharedStrings, cells[n].Value)
+	//		}
+	//		cells[n].Value = strconv.Itoa(i)
+	//	} else if cells[n].Type == CellTypeDatetime {
+	//		d, err := time.Parse(time.RFC3339, cells[n].Value)
+	//		if err == nil {
+	//			cells[n].Value = OADate(d)
+	//		}
+	//	}
+	//}
 
 	row := s.NewRow()
 	row.Cells = cells
@@ -322,11 +322,11 @@ func (ww *WorkbookWriter) WriteHeader(s *Sheet) error {
 		return err
 	}
 
-	f, err = z.Create("xl/sharedStrings.xml")
-	err = TemplateStringLookups.Execute(f, s.SharedStrings())
-	if err != nil {
-		return err
-	}
+	//f, err = z.Create("xl/sharedStrings.xml")
+	//err = TemplateStringLookups.Execute(f, s.SharedStrings())
+	//if err != nil {
+	//return err
+	//}
 
 	return nil
 }

--- a/xlsx.go
+++ b/xlsx.go
@@ -131,13 +131,6 @@ func (s *Sheet) AppendRow(r Row) error {
 				s.sharedStrings = append(s.sharedStrings, cells[n].Value)
 			}
 			cells[n].Value = strconv.Itoa(i)
-		} else if cells[n].Type == CellTypeDatetime {
-			d, err := time.Parse(time.RFC3339, cells[n].Value)
-			if err == nil {
-				cells[n].Value = OADate(d)
-			}
-		} else if cells[n].Type == CellTypeInlineString {
-			cells[n].Value = html.EscapeString(cells[n].Value)
 		}
 	}
 
@@ -380,9 +373,20 @@ func (sw *SheetWriter) WriteRows(rows []Row) error {
 			cell := struct {
 				CellIndex string
 				Value     string
+				Type      CellType
 			}{
 				CellIndex: CellIndex(uint64(j), uint64(i)+sw.currentIndex),
 				Value:     c.Value,
+				Type:      c.Type,
+			}
+
+			if c.Type == CellTypeDatetime {
+				d, err := time.Parse(time.RFC3339, c.Value)
+				if err == nil {
+					cell.Value = OADate(d)
+				}
+			} else if c.Type == CellTypeInlineString {
+				cell.Value = html.EscapeString(c.Value)
 			}
 
 			switch c.Type {

--- a/xlsx.go
+++ b/xlsx.go
@@ -418,6 +418,5 @@ func (sw *SheetWriter) WriteHeader(s *Sheet) error {
 		Cols: s.columns,
 	}
 
-	err := TemplateSheetStart.Execute(sw.f, sheet)
-	return err
+	return TemplateSheetStart.Execute(sw.f, sheet)
 }

--- a/xlsx.go
+++ b/xlsx.go
@@ -368,11 +368,14 @@ func (ww *WorkbookWriter) NewSheetWriter(s *Sheet) (*SheetWriter, error) {
 	sw := &SheetWriter{f, err, 0, 0, false}
 
 	if ww.sheetWriter != nil {
-		ww.sheetWriter.Close()
+		err = ww.sheetWriter.Close()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	ww.sheetWriter = sw
-	sw.WriteHeader(s)
+	err = sw.WriteHeader(s)
 
 	return sw, err
 }

--- a/xlsx.go
+++ b/xlsx.go
@@ -21,6 +21,7 @@ const (
 	CellTypeNumber CellType = iota
 	CellTypeString
 	CellTypeDatetime
+	CellTypeInlineString
 )
 
 // XLSX Spreadsheet Cell
@@ -135,6 +136,8 @@ func (s *Sheet) AppendRow(r Row) error {
 			if err == nil {
 				cells[n].Value = OADate(d)
 			}
+		} else if cells[n].Type == CellTypeInlineString {
+			cells[n].Value = html.EscapeString(cells[n].Value)
 		}
 	}
 
@@ -385,6 +388,8 @@ func (sw *SheetWriter) WriteRows(rows []Row) error {
 			switch c.Type {
 			case CellTypeString:
 				err = TemplateCellString.Execute(rb, cell)
+			case CellTypeInlineString:
+				err = TemplateCellInlineString.Execute(rb, cell)
 			case CellTypeNumber:
 				err = TemplateCellNumber.Execute(rb, cell)
 			case CellTypeDatetime:

--- a/xlsx.go
+++ b/xlsx.go
@@ -201,6 +201,26 @@ func (s *Sheet) SaveToFile(filename string) error {
 	return err
 }
 
+// Save the XLSX file to the given writer
+func (s *Sheet) SaveToWriter(w io.Writer) error {
+
+	ww := NewWorkbookWriter(w)
+
+	sw, err := ww.NewSheetWriter(s)
+	if err != nil {
+		return err
+	}
+
+	err = sw.WriteRows(s.rows)
+	if err != nil {
+		return err
+	}
+
+	err = ww.Close()
+
+	return err
+}
+
 // Save the given rows to the sheet's writer
 func (sw *SheetWriter) WriteRows(rows []Row) error {
 
@@ -249,26 +269,6 @@ func (sw *SheetWriter) WriteRows(rows []Row) error {
 	sw.currentIndex += uint64(len(rows))
 
 	return nil
-}
-
-// Save the XLSX file to the given writer
-func (s *Sheet) SaveToWriter(w io.Writer) error {
-
-	ww := NewWorkbookWriter(w)
-
-	sw, err := ww.NewSheetWriter(s)
-	if err != nil {
-		return err
-	}
-
-	err = sw.WriteRows(s.rows)
-	if err != nil {
-		return err
-	}
-
-	err = ww.Close()
-
-	return err
 }
 
 // Write the header files of the workbook

--- a/xlsx.go
+++ b/xlsx.go
@@ -355,7 +355,10 @@ func (ww *WorkbookWriter) Close() error {
 	return ww.zipWriter.Close()
 }
 
-// Creates a new SheetWriter
+// NewSheetWriter creates a new SheetWriter in this workbook using the given sheet.
+// It returns a SheetWriter to which rows can be written.
+// All rows must be written to the SheetWriter before the next call to NewSheetWriter,
+// as this will automatically close the previous SheetWriter.
 func (ww *WorkbookWriter) NewSheetWriter(s *Sheet) (*SheetWriter, error) {
 	if !ww.headerWritten {
 		err := ww.WriteHeader(s)

--- a/xlsx.go
+++ b/xlsx.go
@@ -7,10 +7,10 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	//"html"
+	"html"
 	"io"
 	"os"
-	//"strconv"
+	"strconv"
 	"time"
 )
 
@@ -116,27 +116,27 @@ func (s *Sheet) AppendRow(r Row) error {
 
 	cells := make([]Cell, len(s.columns))
 
-	//for n, c := range r.Cells {
-	//	cells[n].Type = c.Type
-	//	cells[n].Value = c.Value
+	for n, c := range r.Cells {
+		cells[n].Type = c.Type
+		cells[n].Value = c.Value
 
-	//	if cells[n].Type == CellTypeString {
-	//		// calculate string reference
-	//		cells[n].Value = html.EscapeString(cells[n].Value)
-	//		i, exists := s.sharedStringMap[cells[n].Value]
-	//		if !exists {
-	//			i = len(s.sharedStrings)
-	//			s.sharedStringMap[cells[n].Value] = i
-	//			s.sharedStrings = append(s.sharedStrings, cells[n].Value)
-	//		}
-	//		cells[n].Value = strconv.Itoa(i)
-	//	} else if cells[n].Type == CellTypeDatetime {
-	//		d, err := time.Parse(time.RFC3339, cells[n].Value)
-	//		if err == nil {
-	//			cells[n].Value = OADate(d)
-	//		}
-	//	}
-	//}
+		if cells[n].Type == CellTypeString {
+			// calculate string reference
+			cells[n].Value = html.EscapeString(cells[n].Value)
+			i, exists := s.sharedStringMap[cells[n].Value]
+			if !exists {
+				i = len(s.sharedStrings)
+				s.sharedStringMap[cells[n].Value] = i
+				s.sharedStrings = append(s.sharedStrings, cells[n].Value)
+			}
+			cells[n].Value = strconv.Itoa(i)
+		} else if cells[n].Type == CellTypeDatetime {
+			d, err := time.Parse(time.RFC3339, cells[n].Value)
+			if err == nil {
+				cells[n].Value = OADate(d)
+			}
+		}
+	}
 
 	row := s.NewRow()
 	row.Cells = cells
@@ -322,11 +322,11 @@ func (ww *WorkbookWriter) WriteHeader(s *Sheet) error {
 		return err
 	}
 
-	//f, err = z.Create("xl/sharedStrings.xml")
-	//err = TemplateStringLookups.Execute(f, s.SharedStrings())
-	//if err != nil {
-	//return err
-	//}
+	f, err = z.Create("xl/sharedStrings.xml")
+	err = TemplateStringLookups.Execute(f, s.SharedStrings())
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/xlsx_test.go
+++ b/xlsx_test.go
@@ -2,6 +2,8 @@ package xlsx
 
 import (
 	"bytes"
+	"fmt"
+	"io"
 	"testing"
 	"time"
 )
@@ -130,8 +132,20 @@ func TestTemplates(t *testing.T) {
 		Start: "A1",
 		End:   "C3",
 	}
-	err = TemplateSheet.Execute(&b, sheet)
+
+	err = TemplateSheetStart.Execute(&b, sheet)
 	if err != nil {
-		t.Errorf("template TemplateSheet failed to Execute returning error %s", err.Error())
+		t.Errorf("template TemplateSheetStart failed to Execute returning error %s", err.Error())
+	}
+
+	for i, _ := range sheet.Rows {
+		rb := &bytes.Buffer{}
+		rowString := fmt.Sprintf(`<row r="%d">%s</row>`, uint64(i), rb.String())
+		_, err = io.WriteString(&b, rowString)
+	}
+
+	err = TemplateSheetEnd.Execute(&b, sheet)
+	if err != nil {
+		t.Errorf("template TemplateSheetEnd failed to Execute returning error %s", err.Error())
 	}
 }


### PR DESCRIPTION
This introduces a memory efficient streaming API which allows writing sheets of arbitrary length in constrained memory environments. An example of how to use streaming is found in `examples/large/main.go`. This makes an effort to maintain backwards compatibility at the API level.

There are some more changes which I'll send in separate pull requests, which improve compatibility with other spreadsheet software (Libreoffice, Gnumeric) and add some performance improvements.
